### PR TITLE
Fix: consider attributes in amp-body tag regex

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -85,7 +85,7 @@ function registerSSRHook (options) {
     params.APP = params.APP
       .replace(scriptPattern, '')
 
-    const AMPBody = /<amp-body>([.\S\s]*)<\/amp-body>/g.exec(params.APP)
+    const AMPBody = /<amp-body.*>([.\S\s]*)<\/amp-body>/g.exec(params.APP)
     if (AMPBody) {
       params.APP = AMPBody[1]
     }

--- a/lib/module.js
+++ b/lib/module.js
@@ -85,7 +85,7 @@ function registerSSRHook (options) {
     params.APP = params.APP
       .replace(scriptPattern, '')
 
-    const AMPBody = /<amp-body.*>([.\S\s]*)<\/amp-body>/g.exec(params.APP)
+    const AMPBody = /<amp-body[^>]*>([.\S\s]*)<\/amp-body>/g.exec(params.APP)
     if (AMPBody) {
       params.APP = AMPBody[1]
     }


### PR DESCRIPTION
Nuxt renders <amp-body> as <amp-body data-v-9f6fe6da data-v-2b668894>, so the regex was enhanced to catch those props