### PR TITLE
Do not filter allowed json/ld+json scripts

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -89,7 +89,7 @@ function registerRendererHook (options) {
     }
 
     params.APP = params.APP
-      .replace(scriptPattern, '')
+      .replace(scriptPattern, v => v.includes('application/json') ? v : '') //script of type application/json is allowed
 
     const AMPBody = /<amp-body[^>]*>([.\S\s]*)<\/amp-body>/g.exec(params.APP)
     if (AMPBody) {
@@ -97,7 +97,7 @@ function registerRendererHook (options) {
     }
 
     params.HEAD = params.HEAD
-      .replace(scriptPattern, v => v.includes('custom-element') ? v : '')
+      .replace(scriptPattern, v => (v.includes('custom-element') || v.includes('application/ld+json')) ? v : '')
       .replace(/<\/style>\S*<style [^>]*>/g, '')
       .replace(/<style/, '<style amp-custom')
       .replace('@charset "UTF-8";', '')


### PR DESCRIPTION
script of type application/json is allowed in amp-analytics
`<amp-analytics id="infonline" type="infonline"><script type="application/json"></script></amp-analytics>`

ld+json is allowed in head
`<script type="application/ld+json">...</script>`