### PR TITLE
Fix stateful regex

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -10,7 +10,7 @@ const AMPBoilerplate = '<style amp-boilerplate>body{-webkit-animation:-amp-start
 '<script async src="https://cdn.ampproject.org/v0.js"></script>'
 
 const scriptPattern = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi
-const ampBodyPattern = /<amp-body[^>]*>([.\S\s]*)<\/amp-body>/g
+const ampBodyPattern = /<amp-body[^>]*>([.\S\s]*)<\/amp-body>/
 
 module.exports = function (moduleOptions) {
   const options = {


### PR DESCRIPTION
Can not use "g"  global flag here together with exec since the index is stored globally and follow-up rendering may fail to filter "amp-body" - via https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec