### PR TITLE
Remove hook to respect modules order, removed tag from canonical page

### DIFF
--- a/example/nuxt.config.js
+++ b/example/nuxt.config.js
@@ -8,6 +8,21 @@ module.exports = {
     resourceHints: false
   },
   modules: [
+    [ 'nuxt-i18n', {
+      locales: [ 'en', 'fr' ],
+      defaultLocale: 'en',
+      vueI18n: {
+        fallbackLocale: 'en',
+        messages: {
+          en: {
+            welcome: 'Welcome'
+          },
+          fr: {
+            welcome: 'Bienvenue'
+          }
+        }
+      }
+    } ],
     { handler: require('../') }
   ],
   amp: {

--- a/lib/amp/plugin.js
+++ b/lib/amp/plugin.js
@@ -94,16 +94,19 @@ const createCustomHead = originalHead => function customHead () {
    */
   ensureKey(head, 'link', [])
 
-  if (origin && !head.link.find(l => l.rel === 'canonical' || l.hid === 'canonical')) {
-    const path = this.$isAMP && this.$ampMode !== 'only'
-      ? this.$route.fullPath.replace(/^\/amp(\/.*)?/, '$1')
-      : this.$route.fullPath
+  // Add canonical meta only if page is served as AMP
+  if (this.$ampMode !== false && this.$isAMP === true) {
+    if (origin && !head.link.find(l => l.rel === 'canonical' || l.hid === 'canonical')) {
+      const path = this.$isAMP && this.$ampMode !== 'only'
+        ? this.$route.fullPath.replace(/^\/amp(\/.*)?/, '$1')
+        : this.$route.fullPath
 
-    head.link.push({
-      rel: 'canonical',
-      hid: 'canonical',
-      href: origin + path
-    })
+      head.link.push({
+        rel: 'canonical',
+        hid: 'canonical',
+        href: origin + path
+      })
+    }
   }
 
   /**
@@ -123,7 +126,7 @@ const createCustomHead = originalHead => function customHead () {
     head.bodyAttrs.class += ' __amp'
   }
 
-  // check if amp is disabled for this page
+  // Add amphtml meta only if page has amp counterpart
   if (this.$ampMode !== false && this.$isAMP === false) {
     if (!head.link.find(l => l.rel === 'amphtml' || l.hid === 'amphtml')) {
       const ampPrefix = this.$ampMode === 'only' ? '' : '/amp'

--- a/lib/amp/plugin.js
+++ b/lib/amp/plugin.js
@@ -94,8 +94,10 @@ const createCustomHead = originalHead => function customHead () {
    */
   ensureKey(head, 'link', [])
 
-  // Add canonical meta only if page is served as AMP
-  if (this.$ampMode !== false && this.$isAMP === true) {
+  /**
+   * Add canonical meta and AMP requirement if page is served as AMP
+   */
+  if (this.$isAMP) {
     if (origin && !head.link.find(l => l.rel === 'canonical' || l.hid === 'canonical')) {
       const path = this.$isAMP && this.$ampMode !== 'only'
         ? this.$route.fullPath.replace(/^\/amp(\/.*)?/, '$1')
@@ -107,12 +109,7 @@ const createCustomHead = originalHead => function customHead () {
         href: origin + path
       })
     }
-  }
 
-  /**
-   * add amp requirement if page is served as AMP
-   */
-  if (this.$isAMP) {
     ensureKey(head, 'htmlAttrs', {})
 
     if (vueMetaMajor >= 2) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -30,21 +30,22 @@ module.exports = function (moduleOptions) {
     registerValidator.call(this, options)
   }
 
-  this.nuxt.hook('build:extendRoutes', (routes) => {
-    processRoutes(routes)
-  })
+  processRoutes()
 }
 
-function processRoutes (routes) {
-  for (const route of routes) {
-    route.meta = route.meta || {}
-    route.alias = route.alias || []
-    if (route.path === '/amp' || route.path.indexOf('/amp/') === 0) {
-      route.meta.amp = true
-    } else {
-      route.alias = '/amp' + route.path
+function processRoutes () {
+  this.extendRoutes((routes) => {
+    for (const route of routes) {
+      route.meta = route.meta || {}
+      route.alias = route.alias || []
+
+      if (route.path === '/amp' || route.path.indexOf('/amp/') === 0) {
+        route.meta.amp = true
+      } else {
+        route.alias = '/amp' + route.path
+      }
     }
-  }
+  })
 }
 
 async function registerValidator (options) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -30,7 +30,7 @@ module.exports = function (moduleOptions) {
     registerValidator.call(this, options)
   }
 
-  processRoutes()
+  processRoutes.call(this)
 }
 
 function processRoutes () {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "amphtml-validator": "^1.0.23",
     "chalk": "^2.4.2",
     "consola": "^2.10.1",
+    "nuxt-i18n": "^6.2.1",
     "qs": "^6.8.0"
   },
   "devDependencies": {

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -44,6 +44,10 @@ describe('Render home page', () => {
   test('Valid amphtml link', () => {
     expect(info.amphtml).toEqual(`http://localhost:${port}/amp/`)
   })
+
+  test('Shouldn\'t have canonical link', () => {
+    expect(info.canonical).toBeNull()
+  })
 })
 
 describe('Render AMP version of home page', () => {
@@ -67,7 +71,7 @@ describe('Render AMP version of home page', () => {
     source = await response.text()
   })
 
-  test("Souldn't have amphtml link", () => {
+  test("Shouldn't have amphtml link", () => {
     expect(info.amphtml).toBeNull()
   })
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -25,6 +25,19 @@ afterAll(async () => {
   await nuxt.close()
 })
 
+describe('Generates routes', () => {
+  let routes
+  beforeAll(() => {
+    routes = nuxt.options.router.routes
+  })
+
+  test('Routes should be correctly localized', () => {
+    routes.forEach((route) => {
+      expect(route.alias).toEqual(`/amp${route.path}`)
+    })
+  })
+})
+
 describe('Render home page', () => {
   let info
   beforeAll(async () => {
@@ -56,6 +69,7 @@ describe('Render AMP version of home page', () => {
     const response = await page.goto(url('/amp'))
 
     info = await page.evaluate(() => {
+      const ampAttr = document.documentElement.getAttribute('amp')
       const canonical = document.querySelector('[rel=canonical]').getAttribute('href')
       const amphtml = document.querySelector('[rel=amphtml]')
 
@@ -63,6 +77,7 @@ describe('Render AMP version of home page', () => {
         .map(a => a.getAttribute('custom-element') || a.getAttribute('custom-template'))
 
       return {
+        ampAttr,
         detectedTags,
         canonical,
         amphtml
@@ -71,7 +86,11 @@ describe('Render AMP version of home page', () => {
     source = await response.text()
   })
 
-  test("Shouldn't have amphtml link", () => {
+  test('Should have amp html attribute', () => {
+    expect(info.ampAttr).toEqual('')
+  })
+
+  test('Shouldn\'t have amphtml link', () => {
     expect(info.amphtml).toBeNull()
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1119,6 +1119,14 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@kazupon/vue-i18n-loader@^0.4.0":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@kazupon/vue-i18n-loader/-/vue-i18n-loader-0.4.1.tgz#71730a821ff15754eb004629d673b47f8d80fdd1"
+  integrity sha512-hVznmhnyoUKozGY7pwq/UtPL76UDzb+aiN2YksZZIzCY/MkEqih0MSyEmTGw7+HVWzJRPAlDyoRNR4tWKmkCRw==
+  dependencies:
+    js-yaml "^3.13.1"
+    json5 "^2.1.0"
+
 "@marionebl/sander@^0.6.0":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@marionebl/sander/-/sander-0.6.1.tgz#1958965874f24bc51be48875feb50d642fc41f7b"
@@ -3201,7 +3209,7 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
-cookie@0.4.0:
+cookie@0.4.0, cookie@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
@@ -5685,6 +5693,11 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-https@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-https/-/is-https-1.0.0.tgz#9c1dde000dc7e7288edb983bef379e498e7cb1bf"
+  integrity sha512-1adLLwZT9XEXjzhQhZxd75uxf0l+xI9uTSFaZeSESjL3E1eXSPpO+u5RcgqtzeZ1KCaNvtEwZSTO2P4U5erVqQ==
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -6250,6 +6263,11 @@ jest@^24.9.0:
   dependencies:
     import-local "^2.0.0"
     jest-cli "^24.9.0"
+
+js-cookie@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
 js-levenshtein@^1.1.3:
   version "1.1.6"
@@ -7325,6 +7343,20 @@ nuxt-edge@^2.10.0-26147535.e9c4bcfe:
     "@nuxt/loading-screen" "^1.0.1"
     "@nuxt/opencollective" "^0.3.0"
     "@nuxt/webpack-edge" "2.10.0-26147535.e9c4bcfe"
+
+nuxt-i18n@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/nuxt-i18n/-/nuxt-i18n-6.2.1.tgz#c8148d45543a05837a2edbf199d9e6826ba80ccd"
+  integrity sha512-kpreVj4/VaagGsW9wVRTnNGBbiR/jWyOwJ1PiFd+GNAGGK4jmuQmugniB3/s4Z8yJH9xp5tZRZc3XJK/lz839Q==
+  dependencies:
+    "@babel/parser" "^7.5.5"
+    "@babel/traverse" "^7.5.5"
+    "@kazupon/vue-i18n-loader" "^0.4.0"
+    cookie "^0.4.0"
+    is-https "^1.0.0"
+    js-cookie "^2.2.0"
+    vue-i18n "^8.12.0"
+    vue-i18n-extensions "^0.2.1"
 
 nwsapi@^2.0.7:
   version "2.1.4"
@@ -10511,6 +10543,16 @@ vue-hot-reload-api@^2.3.0:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.3.tgz#2756f46cb3258054c5f4723de8ae7e87302a1ccf"
   integrity sha512-KmvZVtmM26BQOMK1rwUZsrqxEGeKiYSZGA7SNWE6uExx8UX/cj9hq2MRV/wWC3Cq6AoeDGk57rL9YMFRel/q+g==
+
+vue-i18n-extensions@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/vue-i18n-extensions/-/vue-i18n-extensions-0.2.1.tgz#86ebea45a1f9c9594cd124f264e107aea193d7dd"
+  integrity sha512-xBrItI7bEwBnG7eAlnyUARP41JYYn2+ABMR8q1Yh5FM9hHCbs4XPZwG+4+FPeIZ6b5gYk4YUP//m+fWiuU9z9A==
+
+vue-i18n@^8.12.0:
+  version "8.14.1"
+  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-8.14.1.tgz#0ca0a2742c14e0144481655157fffcc7cc313e50"
+  integrity sha512-uHzw5GTFyf/TmjJXveSl3L4CG61KI4lvhKOQvx8W4Y8P2LZ3v3l/qw4KRs1C6pWyjkfY9p0rezYNFO5YzMEQ8A==
 
 vue-loader@^15.7.1:
   version "15.7.1"


### PR DESCRIPTION
Reopened from #34, without the commit spam. Removed hook as per suggestion from @farnabaz, also added a check on the canonical `link` injection, the `rel=canonical` tag should not be on the [regular page](https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/discovery/?format=websites). Maybe should consider instead the amp only situation in which the canonical should point to itself.
