### PR TITLE
fix(route-alis): preserve route previous aliases

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -38,8 +38,9 @@ function processRoutes () {
     for (const route of routes) {
       route.meta = route.meta || {}
       route.alias = route.alias || []
-      if(typeof route.alias === 'string')
-        route.alias = [route.alias];
+      if (typeof route.alias === 'string') {
+        route.alias = [route.alias]
+      }
 
       if (route.path === '/amp' || route.path.indexOf('/amp/') === 0) {
         route.meta.amp = true

--- a/lib/module.js
+++ b/lib/module.js
@@ -38,11 +38,13 @@ function processRoutes () {
     for (const route of routes) {
       route.meta = route.meta || {}
       route.alias = route.alias || []
+      if(typeof route.alias === 'string')
+        route.alias = [route.alias];
 
       if (route.path === '/amp' || route.path.indexOf('/amp/') === 0) {
         route.meta.amp = true
       } else {
-        route.alias = '/amp' + route.path
+        route.alias.push('/amp' + route.path)
       }
     }
   })

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -33,7 +33,7 @@ describe('Generates routes', () => {
 
   test('Routes should be correctly localized', () => {
     routes.forEach((route) => {
-      expect(route.alias).toEqual(`/amp${route.path}`)
+      expect(route.alias).toEqual([`/amp${route.path}`])
     })
   })
 })


### PR DESCRIPTION
Instead of replacing the alias of the route, add an additional alias.
In case other modules create alias or other custom implementations use alias for routes too.