### PR TITLE
fix: Wrong 404 check while mode 'only'

### DIFF
--- a/lib/amp/plugin.js
+++ b/lib/amp/plugin.js
@@ -40,7 +40,7 @@ export default function (ctx, inject) {
     case 'only':
       isAMP = true
       ampMode = 'only'
-      if (options.amp && hasAMPPrefix) {
+      if (options.amp && !hasAMPPrefix) {
         return ctx.error({ statusCode: 404, message: 'This page could not be found' })
       }
       break


### PR DESCRIPTION
We should return 404 while `mode = 'only'` and page does **not** have amp prefix.