### PR TITLE
fix: keep font provides styles

### DIFF
--- a/example/assets/styles/amp-custom.scss
+++ b/example/assets/styles/amp-custom.scss
@@ -2,4 +2,5 @@ $bg-color: #0cf;
 
 body {
     background: $bg-color;
+    font-family: Langar;
 }

--- a/example/pages/index.vue
+++ b/example/pages/index.vue
@@ -132,7 +132,11 @@
 export default {
   head () {
     return {
-      title: 'AMP module for Nuxtjs'
+      title: 'AMP module for Nuxtjs',
+      link: [
+        { rel: 'preconnecy', href: 'https://fonts.gstatic.com' },
+        { hid: 'google-font', rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=Langar&display=swap' }
+      ]
     }
   }
 }
@@ -140,7 +144,7 @@ export default {
 
 <style>
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-family: Langar, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 body > * {
   margin: 0.5rem 0 0.5rem 0.5rem;

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,7 +1,7 @@
 const { resolve, join } = require('path')
 const chalk = require('chalk')
 const { getTags, getNecessaryScripts } = require('./tags')
-const { logger } = require('./utils')
+const { logger, removeExternalStyles } = require('./utils')
 
 const AMPBoilerplate = '<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>' +
 '<script async src="https://cdn.ampproject.org/v0.js"></script>'
@@ -163,10 +163,8 @@ function registerRendererHook (options) {
        * Remove external styles
        */
       .replace(/<style[^>]*>.*?<\/style>/g, '')
-      /**
-       * Remove external stylesheet
-       */
-      .replace(/<link[^>]*rel="stylesheet".*>/gi, '')
+
+    params.HEAD = removeExternalStyles(params.HEAD)
 
     params.HEAD += AMPBoilerplate
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,25 @@
 import consola from 'consola'
 
 export const logger = consola.withScope('@nuxtjs/amp')
+
+export const VALID_FONT_PROVIDERS = [
+  'https://cloud.typography.com',
+  'https://fast.fonts.net',
+  'https://fonts.googleapis.com',
+  'https://use.typekit.net',
+  'https://maxcdn.bootstrapcdn.com',
+  'https://use.fontawesome.com'
+]
+
+/**
+ * Remove external stylesheet links from input head HTML and leave
+ * valid font ptovider styles
+ */
+export function removeExternalStyles (head) {
+  return head.replace(/<link[^>]*rel="stylesheet"[^>]*>/gi, (v) => {
+    if (VALID_FONT_PROVIDERS.some(domain => v.includes(domain))) {
+      return v
+    }
+    return ''
+  })
+}

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -105,7 +105,7 @@ describe('Render AMP version of home page', () => {
     expect(info.canonical).toEqual(url(''))
   })
 
-  test('Keep valid font providers links', () => {
+  test('Keep links of valid font providers', () => {
     expect(info.googleFont).toEqual('https://fonts.googleapis.com/css2?family=Langar&display=swap')
   })
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -77,6 +77,8 @@ describe('Render AMP version of home page', () => {
       const canonical = document.querySelector('[rel=canonical]').getAttribute('href')
       const amphtml = document.querySelector('[rel=amphtml]')
 
+      const googleFont = document.querySelector('[data-hid="google-font"]').getAttribute('href')
+
       const detectedTags = [...document.querySelectorAll('script[custom-element],script[custom-template]')]
         .map(a => a.getAttribute('custom-element') || a.getAttribute('custom-template'))
 
@@ -84,7 +86,8 @@ describe('Render AMP version of home page', () => {
         ampAttr,
         detectedTags,
         canonical,
-        amphtml
+        amphtml,
+        googleFont
       }
     })
     source = await response.text()
@@ -100,6 +103,10 @@ describe('Render AMP version of home page', () => {
 
   test('Valid canonical link', () => {
     expect(info.canonical).toEqual(url(''))
+  })
+
+  test('Keep valid font providers links', () => {
+    expect(info.googleFont).toEqual('https://fonts.googleapis.com/css2?family=Langar&display=swap')
   })
 
   test('Detect all tags', () => {


### PR DESCRIPTION
Do not remove style of font providers that listed in https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/custom_fonts/

close #214