### PR TITLE
feat(styling): keep Nuxt style when `css=false`

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -6,7 +6,7 @@ General options of amp module
 | Option  | Default | Valid values | Description |
 | ------  | ------- | ------------ | ----------- |
 | cdnBase | `https://cdn.ampproject.org/v0/` | Any String | A CDN Domain to load AMP elements scripts |
-| css | `undefined` | Path to CSS style | Custom styles for AMP pages, eg. `~/assets/style/amp-custom.css` |
+| css     | `undefined` | `false` or Path to CSS style | Custom styles for AMP pages, eg. `~/assets/style/amp-custom.css`. By setting this option to `false`, the module will not remove inline styles, instead it will try to merge all inline styles into a single style tag.|
 |  tags   | `{}`    | Object of tag options  | Define new tags or modify current tags, for instance if you want to use `amp-mustache` version 0.1, tags value must be `{ 'amp-mustache': { version: '0.1' } }` |
 | origin  | `` | Any String | Main domain of website. Using this AMP modules tries to add missing canonical link for pages. |
 | mode    | `hybrid` | `only\|hybrid\|false` | Default behaviour of amp module. (`only` all pages serve in AMP mode by default, `hybrid` pages serves in both normal and AMP mode, `false` pages does not serve AMP by default ) |

--- a/lib/module.js
+++ b/lib/module.js
@@ -159,11 +159,25 @@ function registerRendererHook (options) {
 
     params.HEAD = params.HEAD
       .replace(scriptPattern, v => (v.includes('custom-element') || v.includes('application/ld+json')) ? v : '')
-      /**
-       * Remove external styles
-       */
-      .replace(/<style[^>]*>[.\S\s]*?<\/style>/g, '')
 
+    if (options.css !== false) {
+      /**
+       * Remove inline styles
+       */
+      params.HEAD = params.HEAD
+        .replace(/<style[^>]*>[.\S\s]*?<\/style>/g, '')
+    } else {
+      /**
+       * Merge inline styles
+       */
+      params.HEAD = params.HEAD.replace(/<\/style>\S*<style [^>]*>/g, '')
+        .replace(/<style/, '<style amp-custom')
+        .replace('@charset "UTF-8";', '')
+    }
+
+    /**
+     * Remove external styles
+     */
     params.HEAD = removeExternalStyles(params.HEAD)
 
     params.HEAD += AMPBoilerplate

--- a/lib/module.js
+++ b/lib/module.js
@@ -162,7 +162,7 @@ function registerRendererHook (options) {
       /**
        * Remove external styles
        */
-      .replace(/<style[^>]*>.*?<\/style>/g, '')
+      .replace(/<style[^>]*>[.\S\s]*?<\/style>/g, '')
 
     params.HEAD = removeExternalStyles(params.HEAD)
 


### PR DESCRIPTION
When project are mainly targeted for AMP, removing styles creates bad DX. On the pure AMP project developers should should be able to define styles in SFC.  
This PR creates a solution to disable style removal for the pure amp project.

close #215 #216