### PR TITLE
fix(style): resolve uncorrect remove style regex

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -169,10 +169,12 @@ function registerRendererHook (options) {
         .replace(/<style[^>]*>[.\S\s]*?<\/style>/g, v => v.includes('amp-custom') ? v : '')
     }
 
-    /**
-     * Merge inline styles
-     */
-    params.HEAD = params.HEAD.replace(/<\/style>[\S\s]*<style[^>]*>/g, '')
+    const styleRegex = /<style(?: .+?)?>([\s\S]*?)<\/style>/g
+    const styleList = params.HEAD.match(styleRegex).map((css) => {
+      const rawStyle = css.replace(styleRegex, '$1\n')
+      return rawStyle
+    })
+    params.HEAD = params.HEAD.replace(styleRegex, '') + `<style>${styleList.join('\n')}</style>`
 
     /**
      * Mark styles as `amp-custom`

--- a/lib/module.js
+++ b/lib/module.js
@@ -167,14 +167,18 @@ function registerRendererHook (options) {
        */
       params.HEAD = params.HEAD
         .replace(/<style[^>]*>[.\S\s]*?<\/style>/g, v => v.includes('amp-custom') ? v : '')
+        .replace(/<\/style>[\S\s]*<style[^>]*>/g, '')
+    } else {
+      /**
+       * Merge inline styles
+       */
+      const styleRegex = /<style(?: .+?)?>([\s\S]*?)<\/style>/g
+      const styleList = params.HEAD.match(styleRegex).map((css) => {
+        const rawStyle = css.replace(styleRegex, '$1\n')
+        return rawStyle
+      })
+      params.HEAD = params.HEAD.replace(styleRegex, '') + `<style>${styleList.join('\n')}</style>`
     }
-
-    const styleRegex = /<style(?: .+?)?>([\s\S]*?)<\/style>/g
-    const styleList = params.HEAD.match(styleRegex).map((css) => {
-      const rawStyle = css.replace(styleRegex, '$1\n')
-      return rawStyle
-    })
-    params.HEAD = params.HEAD.replace(styleRegex, '') + `<style>${styleList.join('\n')}</style>`
 
     /**
      * Mark styles as `amp-custom`


### PR DESCRIPTION
This pull-request resolves `</style><style>` pattern regex problem.

## Example

## as-is

```javascript
// in: '<style>a {}</style><style>b {}</style><style>c {}</style><style>'
// out: '<style>a {}'

(() => {
  const params = { HEAD: '<style>a {}</style><style>b {}</style><style>c {}</style><style>' }
  return params.HEAD.replace(/<\/style>[\S\s]*<style[^>]*>/g, '')
})()
```

## to-be

```javascript
// in: '<style>a {}</style><style>b {}</style><style>c {}</style><style>'
// out: `<style>a {}
// b {}
// c {}</style>`

(() => {
  const params = { HEAD: '<style>a {}</style><style>b {}</style><style>c {}</style><style>' }

  const styleRegex = /<style(?: .+?)?>([\s\S]*?)<\/style>/g
    const styleList = params.HEAD.match(styleRegex).map((css) => {
      const rawStyle = css.replace(styleRegex, '$1')
      return rawStyle
    })
    return params.HEAD.replace(styleRegex, '') + `${styleList.join('\n')}</style>`
})()
```