### PR TITLE
fix(routes): reorder routes to override AMP pages

### DIFF
--- a/example/pages/amp/hello.vue
+++ b/example/pages/amp/hello.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Hello AMP
+  </div>
+</template>

--- a/example/pages/hello.vue
+++ b/example/pages/hello.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Hello Everyone
+  </div>
+</template>

--- a/lib/module.js
+++ b/lib/module.js
@@ -78,7 +78,8 @@ function processRoutes (options) {
     }
   })
   this.extendRoutes((routes) => {
-    for (const route of routes) {
+    let head = 0
+    for (const [index, route] of routes.entries()) {
       route.meta = route.meta || {}
       route.alias = route.alias || []
       if (typeof route.alias === 'string') {
@@ -86,6 +87,8 @@ function processRoutes (options) {
       }
 
       if (route.path === '/amp' || route.path.indexOf('/amp/') === 0) {
+        routes.splice(head, 0, routes.splice(index, 1)[0])
+        head += 1
         route.meta.amp = true
       } else if (!Array.isArray(options.routeAliases) || options.routeAliases.includes(route.path)) {
         route.alias.push('/amp' + route.path)

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -37,7 +37,9 @@ describe('Generates routes', () => {
 
   test('Routes should be correctly localized', () => {
     routes.forEach((route) => {
-      expect(route.alias).toEqual([`/amp${route.path}`])
+      if (!route.path.startsWith('/amp')) {
+        expect(route.alias).toEqual([`/amp${route.path}`])
+      }
     })
   })
 })
@@ -120,6 +122,30 @@ describe('Render AMP version of home page', () => {
 
   test('Render plain text', () => {
     expect(source).toContain('AMP is easy')
+  })
+})
+
+describe('Render hello page', () => {
+  let source
+  beforeAll(async () => {
+    const response = await page.goto(url('/hello'))
+    source = await response.text()
+  })
+
+  test('Hello Everyone', () => {
+    expect(source).toContain('Hello Everyone')
+  })
+})
+
+describe('Render AMP version of hello page', () => {
+  let source
+  beforeAll(async () => {
+    const response = await page.goto(url('/amp/hello'))
+    source = await response.text()
+  })
+
+  test('Hello AMP', () => {
+    expect(source).toContain('Hello AMP')
   })
 })
 


### PR DESCRIPTION
Move routes with `/amp` prefix to beginning of routes array

close #231 