### PR TITLE
Add space on Regex of html includes

### DIFF
--- a/lib/tags.js
+++ b/lib/tags.js
@@ -145,7 +145,7 @@ function filterTag (html, tag, { isTemplate, regex }) {
   if (regex) {
     return html.search(regex) > -1
   }
-  return html.includes(`<${tag}`)
+  return html.includes(`<${tag} `)
 }
 
 function generateScript (cdnBase, tag, { isTemplate, script, version }) {


### PR DESCRIPTION
Added Space to only include the exact composite name tag

Ex: Add amp-story-player and not the amp-story